### PR TITLE
URIDecode Query String Before Validating Query

### DIFF
--- a/src/parsing/parser.js
+++ b/src/parsing/parser.js
@@ -561,6 +561,7 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     s0 = peg$currPos;
+    input = decodeURI(input);
     if (input.substr(peg$currPos, 2) === peg$c11) {
       s1 = peg$c11;
       peg$currPos += 2;


### PR DESCRIPTION
In regards to issue #4

I  tested this on on firefox and postman and it works. Applications such as postman encodeURI before sending it out. This will decode the query string  before validating the string. I would ask to implement this or create a option to at least set this if needed. In any case a simple decode won't hurt the tool. Only make it better  at the least.

